### PR TITLE
Fix wrong variable name in "create a new feed"

### DIFF
--- a/adafruit-io-python-tutorial.ipynb
+++ b/adafruit-io-python-tutorial.ipynb
@@ -122,7 +122,7 @@
     "try:\n",
     "    test_feed = aio.feeds('test-feed')\n",
     "except RequestError: # Doesn't exist, create a new feed\n",
-    "    test_feed = Feed(name='test-feed')\n",
+    "    test = Feed(name='test-feed')\n",
     "    test_feed = aio.create_feed(test)"
    ]
   },


### PR DESCRIPTION
The current code creates a Feed variable named `test_feed` but in the next line it calls it `test`.  
I think the name `test` is probably the intended one. Change the first variable name to `test`
and assign the `create_feed()` result to `test_feed`.

Another possible fix would be to change the `test` name to `test_feed`, but this seems like it might be more confusing to new folks.  Like this:

    test_feed = Feed(name='test-feed')
    test_feed = aio.create_feed(test_feed)
